### PR TITLE
refactor: update Supabase key references in environment configuration

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,11 +13,10 @@ app.get('/health', (req, res) => {
 });
 
 // Enhanced health check with Supabase connection test
-app.get('/health/detailed', async (req, res) => {
+app.get("/health/detailed", async (_req, res) => {
   try {
-    // Test Supabase connection
-    const { error } = await supabase.from('_test').select('*').limit(1);
-    
+    const { data, error } = await supabase.auth.getSession();
+
     res.json({
       ok: true,
       environment: config.nodeEnv,
@@ -30,7 +29,7 @@ app.get('/health/detailed', async (req, res) => {
   } catch (err) {
     res.status(500).json({
       ok: false,
-      error: 'Health check failed',
+      error: "Health check failed",
       timestamp: new Date().toISOString()
     });
   }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,7 +1,7 @@
 # Supabase Configuration (Frontend)
 # Note: VITE_ prefix is required for Vite to expose these variables to the client
 VITE_SUPABASE_URL=https://your-project-ref.supabase.co
-VITE_SUPABASE_ANON_KEY=your-anon-key-here
+VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY=your-publishable-key-here
 
 # Development Configuration
 VITE_API_BASE_URL=http://localhost:4000

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -5,7 +5,7 @@
 export function validateEnvironment() {
   const requiredVars = [
     'VITE_SUPABASE_URL',
-    'VITE_SUPABASE_ANON_KEY'
+    'VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY'
   ];
 
   const missing = requiredVars.filter(varName => !import.meta.env[varName]);
@@ -24,7 +24,7 @@ export function validateEnvironment() {
 export const config = {
   supabase: {
     url: import.meta.env.VITE_SUPABASE_URL,
-    anonKey: import.meta.env.VITE_SUPABASE_ANON_KEY
+    anonKey: import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY
   },
   api: {
     baseUrl: import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000'


### PR DESCRIPTION
closes #2 

This pull request updates the Supabase authentication configuration to use the publishable key instead of the anon key, and improves the backend health check endpoint to validate Supabase session connectivity rather than just database access. These changes help align the frontend and backend with current Supabase best practices and enhance reliability.

**Supabase authentication configuration update:**

* Renamed the environment variable from `VITE_SUPABASE_ANON_KEY` to `VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY` in `frontend/.env.example`, and updated all references in `frontend/src/config/env.ts` to use the new variable name. [[1]](diffhunk://#diff-7b3b2052ac3e484bcffbb75d7ee140a9ebe7677fd7ea34ac17ca193dd3c0ecfcL4-R4) [[2]](diffhunk://#diff-1cb3c040b6ad73219442c1c9364e80e9df0c6e54f1f4f279ec128ecea7bdb599L8-R8) [[3]](diffhunk://#diff-1cb3c040b6ad73219442c1c9364e80e9df0c6e54f1f4f279ec128ecea7bdb599L27-R27)

**Backend health check improvements:**

* Changed the `/health/detailed` endpoint in `backend/src/index.ts` to test Supabase session connectivity using `supabase.auth.getSession()` instead of querying the `_test` table, providing a more relevant and reliable health check.
* Updated error messaging in the `/health/detailed` endpoint for consistency.