### PR TITLE
chore: add CI workflow for frontend and backend with build and deploy…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI (Frontend + Backend)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  backend:
+    name: Backend - install, build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+  frontend:
+    name: Frontend - install, build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,67 @@
+name: Deploy (Render + Netlify)
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  # Optional: gate deploy behind successful builds
+  build:
+    name: Build gate (frontend + backend)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [backend, frontend]
+    defaults:
+      run:
+        working-directory: ${{ matrix.app }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ${{ matrix.app }}/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+  deploy-backend:
+    name: Trigger Render deploy
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: contains(github.event.head_commit.modified, 'backend/') || contains(github.event.head_commit.added, 'backend/') || contains(github.event.head_commit.removed, 'backend/')
+    steps:
+      - name: Trigger Render deploy (Deploy Hook)
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$RENDER_DEPLOY_HOOK_URL" ]; then
+            echo "Missing secret: RENDER_DEPLOY_HOOK_URL"
+            exit 1
+          fi
+          curl -fsS -X POST "$RENDER_DEPLOY_HOOK_URL"
+          echo "Render deploy triggered."
+
+  deploy-frontend:
+    name: Trigger Netlify deploy
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: contains(github.event.head_commit.modified, 'frontend/') || contains(github.event.head_commit.added, 'frontend/') || contains(github.event.head_commit.removed, 'frontend/')
+    steps:
+      - name: Trigger Netlify build (Build Hook)
+        env:
+          NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
+        run: |
+          if [ -z "$NETLIFY_BUILD_HOOK_URL" ]; then
+            echo "Missing secret: NETLIFY_BUILD_HOOK_URL"
+            exit 1
+          fi
+          curl -fsS -X POST "$NETLIFY_BUILD_HOOK_URL"
+          echo "Netlify build triggered."


### PR DESCRIPTION
closes #29
closes #28 
closes #27 
closes #26 
closes #25
 

This pull request introduces new GitHub Actions workflows for continuous integration and deployment, improving automation for both the frontend and backend projects. The changes ensure that builds are run for both areas on pull requests and pushes, and deployments are triggered to Render and Netlify when relevant changes are made to the respective directories.

**Continuous Integration Workflow Enhancements:**

* Added `.github/workflows/ci.yml` to automate install and build steps for both `backend` and `frontend` on pull requests and pushes to `main`. This ensures that both parts of the project are tested and built consistently.

**Deployment Workflow Automation:**

* Added `.github/workflows/deploy.yml` to automate deployment to Render (for backend) and Netlify (for frontend) on pushes to `main`, with deployment gated behind successful builds. Deployments are only triggered when changes are detected in the respective directories.… 