### PR TITLE
fix: correct Supabase key reference from anonKey to publishableKey in…

### DIFF
--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -24,7 +24,7 @@ export function validateEnvironment() {
 export const config = {
   supabase: {
     url: import.meta.env.VITE_SUPABASE_URL,
-    anonKey: import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY
+    publishableKey: import.meta.env.VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY
   },
   api: {
     baseUrl: import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000'

--- a/frontend/src/config/supabase.ts
+++ b/frontend/src/config/supabase.ts
@@ -4,7 +4,7 @@ import { config } from './env';
 // Create Supabase client with environment variables
 export const supabase = createClient(
   config.supabase.url,
-  config.supabase.anonKey,
+  config.supabase.publishableKey,
   {
     auth: {
       autoRefreshToken: true,


### PR DESCRIPTION


This pull request updates the way Supabase environment variables are referenced and used throughout the frontend configuration. The main change is renaming the Supabase key property to improve clarity and consistency.

**Supabase configuration updates:**

* Renamed the Supabase key property from `anonKey` to `publishableKey` in `config.supabase` within `env.ts` for clearer naming.
* Updated the Supabase client initialization in `supabase.ts` to use `config.supabase.publishableKey` instead of the previous `anonKey` property.… environment configuration